### PR TITLE
add flexibility by providing the name of the variable of interest as …

### DIFF
--- a/widetrax/DataPreprocessing.py
+++ b/widetrax/DataPreprocessing.py
@@ -170,17 +170,17 @@ def fill_nan(datasets, varname: str = "ssha"):
 
     Parameters
     ------------
-    datasets : Dict
+    datasets: Dict
         Dictionary containing xarray.Datasets
-    varname : str, optional
+    varname: str, optional
         Variable name to fill in missing values.
         Defaults to "ssha"
 
     Returns
     ---------
-    has_converged : bool
+    has_converged: bool
         Indicates whether the method has converged, returns True if the method has converged, otherwise returns False
-    filled_dataset : Dict
+    filled_dataset: Dict
         Dictionary containing xarray.Datasets (with missing values filled in)
     """
     has_converged = True

--- a/widetrax/DataPreprocessing.py
+++ b/widetrax/DataPreprocessing.py
@@ -1,20 +1,16 @@
-#Imports
-
+from collections import defaultdict
+from datetime import datetime, timedelta
 import os
+import re
 import sys
-import xarray as xr
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import matplotlib.pyplot as plt
 import numpy as np
 import pyinterp
 import pyinterp.fill as fill
-import re
-from datetime import datetime
-import zarr
-from collections import defaultdict
-import cartopy.crs as ccrs
-import matplotlib.pyplot as plt
-import cartopy.feature as cfeature
-from matplotlib.colors import ListedColormap
-from datetime import datetime, timedelta
+import xarray as xr
 
 
 # =============================================================================
@@ -23,7 +19,6 @@ from datetime import datetime, timedelta
 
 
 def extract_xarray_in_region(directory, area):
-    
     """
     Extracts xarray datasets from SWOT NetCDF data for a specific region
     
@@ -42,54 +37,53 @@ def extract_xarray_in_region(directory, area):
         Dictionary containing the xarray.Datasets for the region
    
     """
-    
-    lon_min, lat_min, lon_max, lat_max = area    
-    datasets = {} 
-    i = 0 
-    
+
+    lon_min, lat_min, lon_max, lat_max = area
+    datasets = {}
+    i = 0
+
     variables_to_load = ["ssha", "mdt", "latitude", "longitude"]
     files_in_dir = os.listdir(directory)
 
     for filename in files_in_dir:
         file_path = os.path.join(directory, filename)
-        
-        
+
         ds_tmp = xr.open_dataset(file_path, chunks={})
         variables_to_drop = [var for var in ds_tmp.variables if var not in variables_to_load]
         ds_tmp.close()
         del ds_tmp
-        
+
         # Open the file (lazy loading) excluding unnecessary variables
         ds = xr.open_dataset(file_path, chunks={}, drop_variables=variables_to_drop)
-        
-        if ds:  
-            if lon_min < lon_max :
+
+        if ds:
+            if lon_min < lon_max:
                 selection = (
-                
-                (ds['latitude'] >= lat_min) &
-                (ds['latitude'] <= lat_max) &
-                (ds['longitude'] >= lon_min) & 
-                (ds['longitude'] <= lon_max)
+
+                        (ds['latitude'] >= lat_min) &
+                        (ds['latitude'] <= lat_max) &
+                        (ds['longitude'] >= lon_min) &
+                        (ds['longitude'] <= lon_max)
                 )
-                        
-            else:    
+
+            else:
                 selection = (
 
-                    (ds['latitude'] >= lat_min) &
-                    (ds['latitude'] <= lat_max) &
-                    (((ds['longitude'] >= lon_min) & (ds['longitude'] <= 360)) | (ds['longitude'] <= lon_max))
+                        (ds['latitude'] >= lat_min) &
+                        (ds['latitude'] <= lat_max) &
+                        (((ds['longitude'] >= lon_min) & (ds['longitude'] <= 360)) | (ds['longitude'] <= lon_max))
 
-                            )
-            
+                )
+
             selection = selection.compute()
-            
-            ds_area = ds.where(selection, drop=True)  
+
+            ds_area = ds.where(selection, drop=True)
             ds.close()
 
-            if ds_area['latitude'].size > 0:  
+            if ds_area['latitude'].size > 0:
                 datasets[i] = ds_area
                 i += 1
-                
+
             ds_area.close()
 
     return datasets
@@ -120,17 +114,16 @@ def count_observations(datasets, area, resolution):
         Array containing the number of observations per pixel
     
     """
-    lon_min,lat_min,lon_max,lat_max = area
-    
+    lon_min, lat_min, lon_max, lat_max = area
 
-    #Define the grid
-    if lon_min > lon_max : # if for example lon_min est 2W=358 et lon max 5E=5 
+    # Define the grid
+    if lon_min > lon_max:  # if for example lon_min est 2W=358 et lon max 5E=5
         lon_grid = np.concatenate([np.arange(lon_min, 360, resolution),
-                                  np.arange(0, lon_max, resolution)])
-    else :
+                                   np.arange(0, lon_max, resolution)])
+    else:
         lon_grid = np.arange(lon_min, lon_max, resolution)
-    
-    #for latitudes    
+
+    # for latitudes
     lat_grid = np.arange(lat_min, lat_max, resolution)
 
     # Create an array filled with zeros
@@ -138,12 +131,12 @@ def count_observations(datasets, area, resolution):
 
     # Iterating on xarrays in datasets dictionnary
     for key in range(len(datasets)):
-        #print(f"{key}/{len(datasets)}")
-    
-        one_dtset = datasets[key].compute() 
-        
-        #Iterating on rows/columns
-        for j in range(one_dtset.ssha.shape[0]):  
+        # print(f"{key}/{len(datasets)}")
+
+        one_dtset = datasets[key].compute()
+
+        # Iterating on rows/columns
+        for j in range(one_dtset.ssha.shape[0]):
             for k in range(one_dtset.ssha.shape[1]):
                 valeur = one_dtset.ssha[j, k]
                 if not np.isnan(valeur):
@@ -154,15 +147,15 @@ def count_observations(datasets, area, resolution):
                     lon_index = int((ln - lon_min) / resolution)
                     lat_index = int((lt - lat_min) / resolution)
 
-                    if lon_index < 0 :
+                    if lon_index < 0:
                         lon_index = int((ln - (lon_min - 360)) / resolution)
 
                     # Increment the corresponding element in obs_count
                     obs_count[lat_index, lon_index] += 1
-  
+
     one_dtset.close()
-    del(one_dtset)
-    
+    del (one_dtset)
+
     return obs_count
 
 
@@ -171,8 +164,7 @@ def count_observations(datasets, area, resolution):
 # =============================================================================
 
 
-def fill_nan(datasets):
-   
+def fill_nan(datasets, varname: str = "ssha"):
     """
     Fills in missing values (NaN) in each xarray.Dataset using Gauss-Seidel method.
 
@@ -180,7 +172,9 @@ def fill_nan(datasets):
     ------------
     datasets : Dict
         Dictionary containing xarray.Datasets
-    
+    varname : str, optional
+        Variable name to fill in missing values.
+        Defaults to "ssha"
 
     Returns
     ---------
@@ -188,48 +182,46 @@ def fill_nan(datasets):
         Indicates whether the method has converged, returns True if the method has converged, otherwise returns False
     filled_dataset : Dict
         Dictionary containing xarray.Datasets (with missing values filled in)
-
     """
-
+    has_converged = True
     filled_datasets = {}
     new_key = 0
     for key in range(len(datasets)):
-        
-        data = datasets[key]
-        
-        latitudes = data['latitude'].values
-        longitudes = data['longitude'].values
-        ssha_values = data['ssha'].values
-        
+
+        # Selects only the variable of interest
+        data = datasets[key][[varname]]
+
+        latitudes = data["latitude"].values
+        longitudes = data["longitude"].values
+        values = data[varname].values
+
         if longitudes.size > 0 and latitudes.size > 0:
-        
+
             # Replace all values in columns 33 and 34 with NaN (the two middle columns)
-            if ssha_values.shape[1]>=34:
-                ssha_values[:, 33:35] = np.nan
+            if values.shape[1] >= 34:
+                values[:, 33:35] = np.nan
 
             # Identify columns entirely NaN
-            nan_columns = np.all(np.isnan(ssha_values), axis=0)
+            nan_columns = np.all(np.isnan(values), axis=0)
 
             # fill NaN data
-
-            x_axis = pyinterp.core.Axis(longitudes[0, :], is_circle=True)  
-            y_axis = pyinterp.core.Axis(latitudes[:, 0], is_circle=False)  
-            grid = pyinterp.Grid2D(y_axis, x_axis, ssha_values)
-            has_converged, filled_ssha_values = fill.gauss_seidel(grid, num_threads=16)
+            x_axis = pyinterp.core.Axis(longitudes[0, :], is_circle=True)
+            y_axis = pyinterp.core.Axis(latitudes[:, 0], is_circle=False)
+            grid = pyinterp.Grid2D(y_axis, x_axis, values)
+            _has_converged, filled_values = fill.gauss_seidel(grid, num_threads=16)
+            has_converged &= _has_converged
 
             # Restore columns entirely NaN
-            filled_ssha_values[:, nan_columns] = np.nan
+            filled_values[:, nan_columns] = np.nan
 
-            # Create a new dataset with filled values and add it to the dictionary
-            filled_data = data.copy()
-            filled_data['ssha'] = (('num_lines', 'num_pixels'), filled_ssha_values)
-            filled_datasets[new_key] = filled_data
+            # Add filled values to the output dictionary
+            datasets[key][varname] = (("num_lines", "num_pixels"), filled_values)
+            filled_datasets[new_key] = datasets[key]
             new_key = new_key + 1
-        else : 
+        else:
             print(f"Size of longitudes/latitudes is zero for dict number {key}")
-        
-    return has_converged, filled_datasets
 
+    return has_converged, filled_datasets
 
 
 # =============================================================================
@@ -262,26 +254,26 @@ def check_directory(database_path, start_date_str, end_date_str):
         If an error occurs, an error message is printed and an empty list is returned.
         
     """
-        
+
     # Regex pattern to match folder names like cycle_001, cycle_002, etc.
     folder_pattern = re.compile(r'cycle_\d{3}')
     # Regex pattern to match the date in the file name SWOT........_YYYYMMDD...
     file_pattern = re.compile(r'SWOT.*_(\d{8})T.*\.nc')
-    
+
     # Convert date strings to datetime objects
     start_date = datetime.strptime(start_date_str, '%Y%m%d')
     end_date = datetime.strptime(end_date_str, '%Y%m%d')
-    
+
     # List to store the names of folders that meet the criteria
     matching_folders = []
-    
+
     try:
         # List all items in the database directory
         items = os.listdir(database_path)
-        
+
         for item in items:
             folder_path = os.path.join(database_path, item)
-            
+
             # Check if the item is a directory and matches the pattern
             if os.path.isdir(folder_path) and folder_pattern.match(item):
                 netcdf_files = [f for f in os.listdir(folder_path) if f.endswith('.nc')]
@@ -290,24 +282,24 @@ def check_directory(database_path, start_date_str, end_date_str):
                     if match:
                         file_date_str = match.group(1)
                         file_date = datetime.strptime(file_date_str, '%Y%m%d')
-                        
+
                         if start_date <= file_date <= end_date:
                             matching_folders.append(item)
                             break  # Stop checking files in this folder once a match is found
-        
+
         return matching_folders
-    
+
     except Exception as e:
         print(f"An error occurred: {e}")
         return []
 
-    
+
 # =============================================================================
 # extract_xarrays_by_time
 # =============================================================================
 
 
-def extract_xarrays_by_time(database_path, start_date_str, end_date_str,area):
+def extract_xarrays_by_time(database_path, start_date_str, end_date_str, area):
     """
     Processes folders in the `database_path` directory, applies the `extract_xarray_in_region` 
     function to each folder that contains NetCDF files within the date range specified 
@@ -333,24 +325,23 @@ def extract_xarrays_by_time(database_path, start_date_str, end_date_str,area):
         A dictionary of xarray.Datasets combining the results from `extract_xarray_in_region` function for each folder.
         
     """
-    
+
     matching_folders = check_directory(database_path, start_date_str, end_date_str)
     combined_datasets_dict = defaultdict(list)
     current_key = 0
-    
+
     for folder in matching_folders:
         folder_path = os.path.join(database_path, folder)
-        result_dict = extract_xarray_in_region(folder_path,area)
-    
+        result_dict = extract_xarray_in_region(folder_path, area)
+
         # Add entries to the combined_dict with sequential keys
         for value in result_dict.values():
             combined_datasets_dict[current_key] = value
             current_key += 1
-            
-            
+
     # Convert defaultdict back to dict
     combined_datasets_dict = dict(combined_datasets_dict)
-    
+
     return combined_datasets_dict
 
 
@@ -359,7 +350,7 @@ def extract_xarrays_by_time(database_path, start_date_str, end_date_str,area):
 # =============================================================================
 
 
-def plot_obs_count(obs_count, area, obs_count2=None ,title=None, title2=None, save_fig=None):
+def plot_obs_count(obs_count, area, obs_count2=None, title=None, title2=None, save_fig=None):
     """
     Plots the number of observations on a geographical map
     
@@ -385,14 +376,14 @@ def plot_obs_count(obs_count, area, obs_count2=None ,title=None, title2=None, sa
     None
         
     """
-    lon_min,lat_min,lon_max,lat_max = area
-    
+    lon_min, lat_min, lon_max, lat_max = area
+
     if lon_min > 180:
         lon_min = lon_min - 360
-        
+
     if lon_max > 180:
         lon_max = lon_max - 360
-        
+
     # Créer des sous-graphes côte à côte
     if obs_count2 is not None:
         fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 12), subplot_kw={'projection': ccrs.PlateCarree()})
@@ -400,64 +391,59 @@ def plot_obs_count(obs_count, area, obs_count2=None ,title=None, title2=None, sa
     else:
         fig, ax1 = plt.subplots(1, 1, figsize=(8, 7), subplot_kw={'projection': ccrs.PlateCarree()})
         maxobs = obs_count.max()
-    
-    
+
     ax1.add_feature(cfeature.LAND, facecolor='gray')
     ax1.set_extent([lon_min, lon_max, lat_min, lat_max], crs=ccrs.PlateCarree())
     # Create a mask for zero values to present the continent in its color
     obs_count_masked = np.ma.masked_where(obs_count == 0, obs_count)
-    
-    im1 = ax1.imshow(obs_count_masked, extent=[lon_min, lon_max, lat_min, lat_max], 
-                   origin='lower', cmap="jet", transform=ccrs.PlateCarree(), 
-                   vmin=0, vmax=maxobs)
-    
+
+    im1 = ax1.imshow(obs_count_masked, extent=[lon_min, lon_max, lat_min, lat_max],
+                     origin='lower', cmap="jet", transform=ccrs.PlateCarree(),
+                     vmin=0, vmax=maxobs)
+
     ax1.coastlines()
     gl1 = ax1.gridlines(draw_labels=True)
-    gl1.right_labels = False  
-    gl1.top_labels = False    
-    
-    plt.colorbar(im1, ax=ax1, label='Number of observations per bin',shrink=0.5)
-    
+    gl1.right_labels = False
+    gl1.top_labels = False
+
+    plt.colorbar(im1, ax=ax1, label='Number of observations per bin', shrink=0.5)
+
     if title:
-        if len(title) >= 40 :
+        if len(title) >= 40:
             ax1.set_title(title, fontsize=11, fontweight='bold', color='black')
-        else :
+        else:
             ax1.set_title(title, fontsize=15, fontweight='bold', color='black')
 
-    if obs_count2 is not None :    
+    if obs_count2 is not None:
         ax2.add_feature(cfeature.LAND, facecolor='gray')
         ax2.set_extent([lon_min, lon_max, lat_min, lat_max], crs=ccrs.PlateCarree())
         # Create a mask for zero values to present the continent in its color
         obs_count_masked2 = np.ma.masked_where(obs_count2 == 0, obs_count2)
 
-        im2 = ax2.imshow(obs_count_masked2, extent=[lon_min, lon_max, lat_min, lat_max], 
-                       origin='lower', cmap="jet", transform=ccrs.PlateCarree(), 
-                       vmin=0, vmax=maxobs)
+        im2 = ax2.imshow(obs_count_masked2, extent=[lon_min, lon_max, lat_min, lat_max],
+                         origin='lower', cmap="jet", transform=ccrs.PlateCarree(),
+                         vmin=0, vmax=maxobs)
 
         ax2.coastlines()
         gl2 = ax2.gridlines(draw_labels=True)
-        gl2.right_labels = False  
-        gl2.top_labels = False 
-        plt.colorbar(im2, ax=ax2, label='Number of observations per bin',shrink=0.5)
+        gl2.right_labels = False
+        gl2.top_labels = False
+        plt.colorbar(im2, ax=ax2, label='Number of observations per bin', shrink=0.5)
         if title2:
             ax2.set_title(title2, fontsize=15, fontweight='bold', color='black')
-    
 
     # Optionally save the figure
     if save_fig is not None:
         plt.savefig(save_fig)
-         
-        
-        
+
 
 # =============================================================================
 # read_zarr_to_xarray_dict
 # =============================================================================         
-        
-        
+
+
 # Fonction pour lire les fichiers Zarr pour une plage de dates spécifique
-def read_zarr_to_xarray_dict(base_directory, area,start_date_str, end_date_str,variables_to_keep):
-    
+def read_zarr_to_xarray_dict(base_directory, area, start_date_str, end_date_str, variables_to_keep):
     """
     
     Reads Zarr files from a directory structure organized by month and day, converts them into a dictionnary of xarray.Dataset objects, retains only specified variables, and extracts a specific geographical region based on latitude and longitude limits.
@@ -483,18 +469,18 @@ def read_zarr_to_xarray_dict(base_directory, area,start_date_str, end_date_str,v
         A dictionary containing the resulting xarray.Dataset objects, indexed by unique integers.
 
     """
-    
+
     lon_min = area[0]
     lon_max = area[2]
     lat_min = area[1]
     lat_max = area[3]
-    
-    #le nombre de fichiers
+
+    # le nombre de fichiers
     nfiles = 0
-    
+
     datasets_dict = {}
     index = 0
-    
+
     # Convertir les chaînes de date en objets datetime
     start_date = datetime.strptime(start_date_str, '%Y%m%d')
     end_date = datetime.strptime(end_date_str, '%Y%m%d')
@@ -504,66 +490,65 @@ def read_zarr_to_xarray_dict(base_directory, area,start_date_str, end_date_str,v
     while current_date <= end_date:
         month = current_date.strftime('%m')
         day = current_date.strftime('%d')
-        
 
         month_directory = os.path.join(base_directory, f'month={month}')
         if os.path.exists(month_directory):
             day_directory = os.path.join(month_directory, f'day={day}')
             if os.path.exists(day_directory):
-                
+
                 zarr_ds = xr.open_zarr(day_directory)
-                
+
                 # Garder uniquement les variables spécifiées
                 zarr_ds = zarr_ds[variables_to_keep]
-                
+
                 coord_vars = ['latitude', 'longitude']
                 zarr_ds = zarr_ds.set_coords(coord_vars)
 
-                if lon_min > lon_max :
-                    
+                if lon_min > lon_max:
+
                     selection = (
 
-                    (zarr_ds['latitude'] >= lat_min) &
-                    (zarr_ds['latitude'] <= lat_max) &
-                    (((zarr_ds['longitude'] >= lon_min) & (zarr_ds['longitude'] <= 360)) | (zarr_ds['longitude'] <= lon_max))
-                            )
+                            (zarr_ds['latitude'] >= lat_min) &
+                            (zarr_ds['latitude'] <= lat_max) &
+                            (((zarr_ds['longitude'] >= lon_min) & (zarr_ds['longitude'] <= 360)) | (
+                                        zarr_ds['longitude'] <= lon_max))
+                    )
                 else:
                     selection = (
 
-                    (zarr_ds['latitude'] >= lat_min) &
-                    (zarr_ds['latitude'] <= lat_max) &
-                    (zarr_ds['longitude'] >= lon_min) & 
-                    (zarr_ds['longitude'] <= lon_max)
-                            )
-            
+                            (zarr_ds['latitude'] >= lat_min) &
+                            (zarr_ds['latitude'] <= lat_max) &
+                            (zarr_ds['longitude'] >= lon_min) &
+                            (zarr_ds['longitude'] <= lon_max)
+                    )
+
                 selection = selection.compute()
-            
-                zarr_ds = zarr_ds.where(selection, drop=True)  
-                
-                #créer la variable ssha
-                zarr_ds['ssha'] =  zarr_ds.duacs_ssha_karin_2_calibrated.where(zarr_ds.duacs_editing_flag == 0)
+
+                zarr_ds = zarr_ds.where(selection, drop=True)
+
+                # créer la variable ssha
+                zarr_ds['ssha'] = zarr_ds.duacs_ssha_karin_2_calibrated.where(zarr_ds.duacs_editing_flag == 0)
                 zarr_ds = zarr_ds.drop_vars('duacs_ssha_karin_2_calibrated')
                 zarr_ds = zarr_ds.drop_vars('duacs_editing_flag')
-                
-                #créer la variable mdt
-                zarr_ds['mdt'] =  zarr_ds.cvl_mean_dynamic_topography_cnes_cls_22
+
+                # créer la variable mdt
+                zarr_ds['mdt'] = zarr_ds.cvl_mean_dynamic_topography_cnes_cls_22
                 zarr_ds = zarr_ds.drop_vars('cvl_mean_dynamic_topography_cnes_cls_22')
-                
+
                 datasets_dict[index] = zarr_ds
-                
-                index +=1
-                nfiles +=1
+
+                index += 1
+                nfiles += 1
 
             else:
                 print(f'The directory for day{day} does not exist in month {month}')
         else:
             print(f'The directory for month{month} does not exist')
-        
+
         # Passer au jour suivant
         current_date += timedelta(days=1)
-        
-    return datasets_dict     
 
+    return datasets_dict
 
 
 # =============================================================================
@@ -598,33 +583,32 @@ def split_dsets_based_cnum(datasets_dict):
         A new dictionary containing the split xarray.dataset objects.
     
     """
-    
-    
+
     splited_dict = {}
     index = 0
-    
+
     for key in range(len(datasets_dict)):
         # Check if the condition is met (you can define your own condition here)
-        if len(np.unique(datasets_dict[key].cycle_number.compute())) >= 2 :
-            #recuperer le num de cycle
+        if len(np.unique(datasets_dict[key].cycle_number.compute())) >= 2:
+            # recuperer le num de cycle
             long_cycle = len(np.unique(datasets_dict[key].cycle_number.compute()))
-            #print(f"la longuer de cycle number est {long_cycle}")
-            
-            for i in np.arange(long_cycle-1) :
+            # print(f"la longuer de cycle number est {long_cycle}")
+
+            for i in np.arange(long_cycle - 1):
                 cycle = np.unique(datasets_dict[key].cycle_number.compute())[i]
-                ds_cycle = datasets_dict[key].where(datasets_dict[key]['cycle_number'].compute() == cycle.astype(float), drop=True)
-               
-                #condition séparation sur les pass number
+                ds_cycle = datasets_dict[key].where(datasets_dict[key]['cycle_number'].compute() == cycle.astype(float),
+                                                    drop=True)
+
+                # condition séparation sur les pass number
                 if len(np.unique(ds_cycle.pass_number.compute())) >= 2:
-                    
+
                     long_pass = len(np.unique(ds_cycle.pass_number.compute()))
-                    #print(f"la longuer de pass number est {long_pass}")
-                    
-                    for i in np.arange(long_pass-1) :
+                    # print(f"la longuer de pass number est {long_pass}")
+
+                    for i in np.arange(long_pass - 1):
                         passs = np.unique(ds_cycle.pass_number.compute())[i]
                         ds_cyclepass = ds_cycle.where(ds_cycle.pass_number.compute() == passs.astype(float), drop=True)
-    
-                
+
                         # Add the new datasets to the output dictionary with sequential keys
                         splited_dict[index] = ds_cyclepass
                         index += 1
@@ -632,8 +616,9 @@ def split_dsets_based_cnum(datasets_dict):
             # If the dataset doesn't meet the condition, add it to the output dictionary as is
             splited_dict[index] = datasets_dict[key]
             index += 1
-    
+
     return splited_dict
+
 
 # =============================================================================
 # remove_duplicates_from_sys_path
@@ -658,6 +643,3 @@ def remove_duplicates_from_sys_path():
             new_sys_path.append(path)
             seen.add(path)
     sys.path = new_sys_path
-
-
-

--- a/widetrax/Spectram.py
+++ b/widetrax/Spectram.py
@@ -1,19 +1,29 @@
-#Imports
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 import numpy as np
 import scipy.signal as signal
-import matplotlib.pyplot as plt
-
-
-
 
 
 # =============================================================================
 # retrieve_segments
 # =============================================================================
 
-    
-def retrieve_segments(datasets,FileType):
+def retrieve_segment(col, dataset, varname):
+    col_data = dataset.isel(num_pixels=col)
+
+    if not np.all(np.isnan(col_data[varname])):
+        segment_data = col_data[varname].values.squeeze()
+
+        finite_idx = np.flatnonzero(np.isfinite(segment_data))
+        segment_data = segment_data[finite_idx.min():finite_idx.max()]
+
+        if not np.isnan(segment_data).any():
+            return segment_data
+
+    return None
+
+
+def retrieve_segments(datasets, varname: str = "ssha"):
     """
     Extracts segments from xarray.datasets
     
@@ -21,64 +31,42 @@ def retrieve_segments(datasets,FileType):
     ------------
     datasets : Dict
         Dictionary containing xarray.Datasets
-    FileType : str
-        The file type used to calculate datasets, "NetCDF" or "Zarr"
+    varname : str, optional
+        Variable name to fill in missing values.
+        Defaults to "ssha"
 
     Returns
     ---------
     segments_dict : Dict
-        Dictionary containing segments (numpy.arrays).
-    
-
+        Dictionary containing segments (numpy.arrays)
     """
     segments_dict = {}
     counter = 0
-    
-    #Calculation of Sea Surface Height (SSH) : SSH = SSHA + MDT
-    for ky in range(len(datasets)):
-        datasets[ky]['ssh'] = datasets[ky]['ssha'] + datasets[ky]['mdt']
-    
-    for key, dataset in datasets.items():
-        print(f"starting processing dict number {key} among {len(datasets)}")
-        for col in range(dataset.dims['num_pixels']):
-            # Extract data for one column
-            col_data = dataset.isel(num_pixels=col)
-            
-            # Delete coords to avoid duplicates and variables we don't need
-            if FileType == "NetCDF":
-                col_dataset = col_data.drop_vars(['latitude', 'longitude','ssha', 'mdt'])
-                
-            elif FileType == "Zarr":
-                col_dataset = col_data.drop_vars(['latitude', 'longitude','ssha', 'mdt',
-                                                  'cycle_number','duacs_land_sea_mask','pass_number'])
-            else:
-                print("The specified format is not supported")
-            
-            
-            # Check whether the column is entirely NaN
-            if not np.all(np.isnan(col_dataset['ssh'])):
-                
-                segment_data = col_dataset.to_array().values.squeeze()
-                
-                # Remove NaN values at the beginning
-                while len(segment_data) > 0 and np.isnan(segment_data[0]):
-                    segment_data = segment_data[1:]
 
-                # Remove NaN values at the end
-                while len(segment_data) > 0 and np.isnan(segment_data[-1]):
-                    segment_data = segment_data[:-1]
-                
-                # Verify if any NaN values remain for islands or continents after interpolation
-                if not np.isnan(segment_data).any():
-                    segments_dict[counter] = segment_data
+    for key, dataset in datasets.items():
+        print(f"Processing dataset {key + 1} among {len(datasets)}")
+
+        with ProcessPoolExecutor() as executor:
+            futures = [
+                executor.submit(retrieve_segment, col, dataset, varname) for col in range(dataset.sizes["num_pixels"])
+            ]
+
+            for future in as_completed(futures):
+                result = future.result()
+                if result is not None:
+                    segments_dict[counter] = result
                     counter += 1
-                
+
     return segments_dict
 
 
 # =============================================================================
 # calculate_psd
 # =============================================================================
+
+def calculate_segment_psd(segment_data, fs):
+    if len(segment_data) > 199:  # Check segment length
+        return signal.welch(segment_data, fs=fs, nperseg=len(segment_data), noverlap=0)
 
 
 def calculate_psd(segments_dict):
@@ -89,32 +77,30 @@ def calculate_psd(segments_dict):
     ------------
     segments_dict : Dict
         Dictionary containing segments (numpy.arrays)
-    
-    
+
     Returns
     ---------
-    
     psd_dict : Dict
         Dictionary containing PSDs for each segment
     freqs_dict : Dict
         Dictionary containing the associated frequencies
-    
-    
     """
+    fs = 0.5  # maybe it could be an argument?
+
     psd_dict = {}
     freqs_dict = {}
-    new_key = 0
-    #fs = 3.25 #sampling frequency = sat speed/distance between each two values(6.5/2)
-    fs = 0.5
-    #fs = 0.0005
-    #fs = (2 * math.pi)/2000
+    counter = 0
 
-    for key, segment_data in segments_dict.items():
-        if len(segment_data) > 199:  # Check segment length
-            freqs, psd = signal.welch(segment_data, fs=fs, nperseg=len(segment_data), noverlap=0)
-            psd_dict[new_key] = psd
-            freqs_dict[new_key] = freqs
-            new_key += 1
+    with ProcessPoolExecutor() as executor:
+        futures = [executor.submit(calculate_segment_psd, segment_data, fs) for segment_data in segments_dict.values()]
+
+        for future in as_completed(futures):
+            result = future.result()
+            if result is not None:
+                freqs, psd = result
+                psd_dict[counter] = psd
+                freqs_dict[counter] = freqs
+                counter += 1
 
     return psd_dict, freqs_dict
 
@@ -122,67 +108,51 @@ def calculate_psd(segments_dict):
 # =============================================================================
 # psd_mean_and_freq
 # =============================================================================        
- 
-    
+
+
 def psd_mean_and_freq(psd_dict, freqs_dict):
     """
-    Calculate the mean of the Power Spectral Densities (PSD) for each frequency point using the values from a PSD dictionary.
+    Calculate the mean of the Power Spectral Densities (PSD) for each frequency point using the values from a PSD
+    dictionary.
 
     Parameters
     ------------
     psd_dict : Dict
-        A dictionary of numpy arrays containing the Power Spectral Densities (PSD) for segments. The arrays can be of different lengths.
-    
+        A dictionary of numpy arrays containing the Power Spectral Densities (PSD) for segments.
+        The arrays can be of different lengths.
     freqs_dict : Dict
         A dictionary containing the corresponding frequencies for each segment (numpy array)
 
     Returns
     ---------
     psd_mean : np.ndarray
-        A numpy array containing the mean of the Power Spectral Densities (PSD) for each frequency point. The length of this array is equal to the maximum length of the arrays in psd_dict.
-    
+        A numpy array containing the mean of the Power Spectral Densities (PSD) for each frequency point.
+        The length of this array is equal to the maximum length of the arrays in psd_dict.
     freqs_mean : np.ndarray 
         A numpy array containing frequency values of the longest column in freqs_dict
-    
     """
-    
-    
-    max_length = max(len(array) for array in psd_dict.values())
+    max_length = 0
+    freqs_mean = None
+    for k, array in psd_dict.items():
+        if array.size > max_length:
+            max_length = array.size
+            freqs_mean = freqs_dict[k]
 
-    # Initialize 2 arrays.
     psd_sum = np.zeros(max_length)
-    counts = np.zeros(max_length)
-
+    psd_counts = np.zeros(max_length)
     for array in psd_dict.values():
-        # Adjust the array to the maximum size by adding NaNs
-        padded_array = np.full(max_length, np.nan)
-        padded_array[:len(array)] = array
-        
-        # Calculate the sum of the PSD values, ignoring the NaNs
-        psd_sum = np.nansum([psd_sum, padded_array], axis=0)
-        
-        # Count the non-NaN values
-        counts = np.nansum([counts, ~np.isnan(padded_array)], axis=0)
+        psd_sum[:array.size] += array
+        psd_counts[:array.size] += 1
+    psd_mean = psd_sum / psd_counts
 
-    # Calculate the PSD mean (np.array)
-    psd_mean = psd_sum / counts
-
-    # take the frequency of the longest column
-    for k, array in freqs_dict.items():
-        if len(array) == max_length:
-            freqs_mean = array
-            break
-               
-    return psd_mean, freqs_mean        
-
+    return psd_mean, freqs_mean
 
 
 # =============================================================================
 # plot_psd
 # ============================================================================= 
 
-
-def plot_psd(ax,freqs, psd1,psd2=None,title=None,psd1_label=None,psd2_label=None):
+def plot_psd(ax, freqs, psds, unit, psd_labels, title=None):
     """
     Plots the Power Spectral Density (PSD) on a logarithmic scale.
     
@@ -202,71 +172,50 @@ def plot_psd(ax,freqs, psd1,psd2=None,title=None,psd1_label=None,psd2_label=None
         The axes on which to plot the PSD. 
     freqs : np.ndarray
         A numpy array containing frequency values.
-    psd1 : np.ndarray
-        A numpy array of PSD values corresponding to `freqs` for the first PSD array.
-    psd2 : np.ndarray, optional
-        Array of PSD values corresponding to `freqs` for the second PSD array, used for comparison.
+    psds : [np.ndarray, ...] | np.ndarray
+        A list of numpy array or a single numpy array of PSD values corresponding to `freqs`.
+    unit : str
+        Unit of the physical quantity for which the PSD was computed.
+    psd_labels : [str, ...] | str, optional
+        A list of labels or a single label for the PDS array(s).
     title : str, optional
         Title of the plot.
-    psd1_label : str, optional
-        Label for the first PSD array. Default is `psd1`.
-    psd2_label : str, optional
-        Label for the second PSD array. Default is `psd2`.
-    
-
-    Returns
-    ---------
-    None
-
     """
-   
-    if len(freqs) == 0 or len(psd1) == 0 :
-        print("Empty data provided.")
-        return
-    
-    if psd1_label :
-        ax.loglog(freqs,psd1,label=psd1_label,color='red')
-    else:
-        ax.loglog(freqs,psd1,label="psd1",color='red')
-        
-    if psd2 is not None and len(psd2) > 0: 
-        if psd2_label :   
-            ax.loglog(freqs,psd2,label=psd2_label,color='green')
-        else:
-            ax.loglog(freqs,psd2,label="psd2",color='blue')
+    if isinstance(psds, np.ndarray):
+        psds = [psds]
+        psd_labels = [psd_labels]
+    if psd_labels is None:
+        psd_labels = [None] * len(psds)
+
+    for psd, label in zip(psds, psd_labels):
+        ax.loglog(freqs, psd, label=label)
 
     ax.set_ylim(1e-7, 1e2)
-    ax.set_ylabel('PSD [m²/(cy/km)]', fontsize=8, fontweight='bold', color='black')                
+    ax.set_ylabel(f"PSD [${unit}/(cy/km)$]", fontsize=8, fontweight="bold", color="black")
 
-    ax.xaxis.set_label_position('top')
+    ax.xaxis.set_label_position("top")
     ax.xaxis.tick_top()
-    ax.set_xlabel('Wavenumber [cy/km]', fontsize=8, fontweight='bold', color='black')
+    ax.set_xlabel("Wavenumber [$cy/km$]", fontsize=8, fontweight="bold", color="black")
 
-
-    #filters out zero frequencies 
+    # filters out zero frequencies
     non_zero_freqs = freqs[freqs != 0]
-    wavelengths_km = 1 / non_zero_freqs
 
     # k^-2 & k^-5
-    k_2 = non_zero_freqs**-2 * (psd1[0] / (non_zero_freqs[0]**-2)) # Scale according to the first PSD value
-    k_5 = non_zero_freqs**-5 * (psd1[0] / (non_zero_freqs[0]**-5))# 
+    k_2 = non_zero_freqs ** -2 * (psds[0][0] / (non_zero_freqs[0] ** -2))  # Scale according to the first PSD value
+    k_5 = non_zero_freqs ** -5 * (psds[0][0] / (non_zero_freqs[0] ** -5))
 
-    ax.loglog(non_zero_freqs, k_2*30, 'k--', label='$k^{-2}$') #30 to fix the line
-    ax.loglog(non_zero_freqs, k_5*1e6, 'b--', label='$k^{-5}$') #1e6 to fix  the line
+    ax.loglog(non_zero_freqs, k_2*30, "k--", label="$k^{-2}$")  # 30 to fix the line
+    ax.loglog(non_zero_freqs, k_5*1e6, "b--", label="$k^{-5}$")  # 1e6 to fix the line
 
-    # 
-    ax2 = ax.secondary_xaxis('bottom', functions=(lambda x: 1/x, lambda x: 1/x))
-    ax2.set_xlabel('Wave-length [km]', fontsize=8, fontweight='bold', color='black')
+    ax2 = ax.secondary_xaxis("bottom", functions=(lambda x: 1 / x, lambda x: 1 / x))
+    ax2.set_xlabel("Wave-length [$km$]", fontsize=8, fontweight="bold", color="black")
 
-    wavelength_ticks = np.array([5,10, 25, 50, 100, 200, 500, 1000])
+    wavelength_ticks = np.array([5, 10, 25, 50, 100, 200, 500, 1000])
     ax2.set_xticks(wavelength_ticks)
     ax2.set_xticklabels(wavelength_ticks)
-    ax.grid(True, which='both')
+    ax.grid(True, which="both")
     ax.legend()
-    
+
     # Set the title if provided
     if title:
-        ax.set_title(title, fontsize=15, fontweight='bold', color='black')
-
-
-
+        ax.set_title(title, fontsize=15, fontweight="bold", color="black")

--- a/widetrax/Spectram.py
+++ b/widetrax/Spectram.py
@@ -32,7 +32,7 @@ def retrieve_segments(datasets, varname: str = "ssha"):
     datasets: Dict
         Dictionary containing xarray.Datasets
     varname: str, optional
-        Variable name to fill in missing values.
+        Variable name for which PSD will be computed.
         Defaults to "ssha"
 
     Returns
@@ -46,9 +46,11 @@ def retrieve_segments(datasets, varname: str = "ssha"):
     for key, dataset in datasets.items():
         print(f"Processing dataset {key + 1} among {len(datasets)}")
 
+        ds = dataset[[varname]]
+
         with ProcessPoolExecutor() as executor:
             futures = [
-                executor.submit(retrieve_segment, col, dataset, varname) for col in range(dataset.sizes["num_pixels"])
+                executor.submit(retrieve_segment, col, ds, varname) for col in range(dataset.sizes["num_pixels"])
             ]
 
             for future in as_completed(futures):

--- a/widetrax/Spectram.py
+++ b/widetrax/Spectram.py
@@ -50,7 +50,7 @@ def retrieve_segments(datasets, varname: str = "ssha"):
 
         with ProcessPoolExecutor() as executor:
             futures = [
-                executor.submit(retrieve_segment, col, ds, varname) for col in range(dataset.sizes["num_pixels"])
+                executor.submit(retrieve_segment, col, ds, varname) for col in range(ds.sizes["num_pixels"])
             ]
 
             for future in as_completed(futures):

--- a/widetrax/Spectram.py
+++ b/widetrax/Spectram.py
@@ -29,15 +29,15 @@ def retrieve_segments(datasets, varname: str = "ssha"):
     
     Parameters
     ------------
-    datasets : Dict
+    datasets: Dict
         Dictionary containing xarray.Datasets
-    varname : str, optional
+    varname: str, optional
         Variable name to fill in missing values.
         Defaults to "ssha"
 
     Returns
     ---------
-    segments_dict : Dict
+    segments_dict: Dict
         Dictionary containing segments (numpy.arrays)
     """
     segments_dict = {}
@@ -75,14 +75,14 @@ def calculate_psd(segments_dict):
     
     Parameters
     ------------
-    segments_dict : Dict
+    segments_dict: Dict
         Dictionary containing segments (numpy.arrays)
 
     Returns
     ---------
-    psd_dict : Dict
+    psd_dict: Dict
         Dictionary containing PSDs for each segment
-    freqs_dict : Dict
+    freqs_dict: Dict
         Dictionary containing the associated frequencies
     """
     fs = 0.5  # maybe it could be an argument?
@@ -117,18 +117,18 @@ def psd_mean_and_freq(psd_dict, freqs_dict):
 
     Parameters
     ------------
-    psd_dict : Dict
+    psd_dict: Dict
         A dictionary of numpy arrays containing the Power Spectral Densities (PSD) for segments.
         The arrays can be of different lengths.
-    freqs_dict : Dict
+    freqs_dict: Dict
         A dictionary containing the corresponding frequencies for each segment (numpy array)
 
     Returns
     ---------
-    psd_mean : np.ndarray
+    psd_mean: np.ndarray
         A numpy array containing the mean of the Power Spectral Densities (PSD) for each frequency point.
         The length of this array is equal to the maximum length of the arrays in psd_dict.
-    freqs_mean : np.ndarray 
+    freqs_mean: np.ndarray
         A numpy array containing frequency values of the longest column in freqs_dict
     """
     max_length = 0
@@ -168,17 +168,17 @@ def plot_psd(ax, freqs, psds, unit, psd_labels, title=None):
     
     Parameters
     ------------
-    ax : matplotlib.axes.Axes
+    ax: matplotlib.axes.Axes
         The axes on which to plot the PSD. 
-    freqs : np.ndarray
+    freqs: np.ndarray
         A numpy array containing frequency values.
-    psds : [np.ndarray, ...] | np.ndarray
+    psds: [np.ndarray, ...] | np.ndarray
         A list of numpy array or a single numpy array of PSD values corresponding to `freqs`.
-    unit : str
+    unit: str
         Unit of the physical quantity for which the PSD was computed.
-    psd_labels : [str, ...] | str, optional
+    psd_labels: [str, ...] | str, optional
         A list of labels or a single label for the PDS array(s).
-    title : str, optional
+    title: str, optional
         Title of the plot.
     """
     if isinstance(psds, np.ndarray):


### PR DESCRIPTION
See #3 

- `fill_nan` and `retrieve_segment` are now taking a `varname` argument, allowing to specify the dataset variable used (rather than defaulting to `ssha`). Note that in order to compute the PSD of the SSH, it now requires to create a `ssh` (for example) variable being the sum of `mdt` and `ssha` 
- `plot_psd` now takes:
  -  a list of `np.ndarray` or a single `np.ndarray` of PSD(s) as argument (rather than `psd1` and an optional `psd2`),
  - a string specifying the unit of the variable for which the PSD was computed,
  - a list of string or a single string as label(s) corresponding to the PSD(s) (optional).
  - 
Those changes allow to compute and plot the PSD of the (E)KE (for example), for several filtered version of `ssha` (for example).

- `retrieve_segments` and `calculate_psd` use a `ProcessPoolExecutor` to operate in "parallel" on the segments.